### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: Build
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Vagab0nd/AniDB.Api/security/code-scanning/2](https://github.com/Vagab0nd/AniDB.Api/security/code-scanning/2)

To fix the problem, explicitly set the least-privilege permissions required by the workflow, either at the workflow root or at the job level. Since only the `build` job is present in this workflow, adding a `permissions` block at the root applies to all jobs and is the clearest approach. Most .NET build/publish tasks require only `contents: read`, but steps that use `${{ secrets.GITHUB_TOKEN }}` to publish packages to GitHub Packages may require the `packages: write` permission. For safest minimal permissions, we set `contents: read` and add `packages: write` only if needed.

Edit `.github/workflows/build.yml` near the top (after the `name:` and before `on:`), adding:
```yaml
permissions:
  contents: read
  packages: write
```
This ensures the workflow follows least privilege while still supporting artifact publication to GitHub Packages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
