### PR TITLE
Remove .NET 8.0 support - Migrate to .NET 10 exclusive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4.3.1
       with:
-        dotnet-version: |
-          8.0.x
-          10.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
 	<PropertyGroup>
 		<!--General options-->
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ All users of this API should employ heavy local caching.
 In case of data dumps (Anime titles) requesting the same dataset multiple times on a single day can get you banned. 
 The same goes for Http API request flooding. You should not request more than one page every two seconds.
 
+## 🔧 Requirements
+
+This library requires **.NET 10.0** or later. 
+
+> **Note**: Previous versions of this library supported .NET 8.0. If you need .NET 8.0 support, please use library version 0.7.3 or earlier.
+
 ## ☂️ Coverage
 
 Coverage as of right now is:
@@ -88,12 +94,9 @@ Coverage as of right now is:
 
 ## 📝 Roadmap
 
-- .Net10 support.
 - Implement UDP API.
 - Use ISO 639 language codes.
 - Add more comprehensive integration tests that check data mapping/validity
-- Use `DateOnly` in models when migrating to .Net7 or higher - support for `DateOnly` conversion to/from XML.
-- Use `required` keyword instead of null collapse in DTOs when migrating to .Net7 or higher.
 
 ## ➕ Contributing
 


### PR DESCRIPTION
# Remove .NET 8.0 support - Migrate to .NET 10 exclusive

## Summary
This PR removes .NET 8.0 support and makes .NET 10 the exclusive target framework. As .NET 8.0 is approaching end-of-support, this migration simplifies the build process while maintaining compatibility for users on modern .NET versions.

## 🚨 Breaking Change
**BREAKING CHANGE**: This version requires .NET 10.0 or later.
- Consumers on .NET 8.0 must use library version **0.7.3 or earlier**
- Recommend bumping version number for clear consumer communication

## Changes
- **Directory.Build.props**: Updated `TargetFrameworks` from `net8.0;net10.0` to `net10.0`
- **.github/workflows/build.yml**: Simplified CI/CD to build/test only .NET 10.0.x (removed 8.0.x)
- **README.md**: Added "🔧 Requirements" section documenting .NET 10 requirement; removed outdated .NET 8 roadmap item

## Verification
✅ Multi-project build succeeded with net10.0 only  
✅ All 5 projects compile to single net10.0 target  
✅ NuGet packages verified to contain only net10.0 assemblies (Core, Http, Udp, Meta)  
✅ CI/CD workflow simplified to single .NET version  
✅ Documentation updated with breaking change notice

## Benefits
- **Simplified Build**: Single target framework reduces build complexity and time
- **Modern Baseline**: Ensures users have access to latest .NET 10 features
- **Reduced CI/CD Runtime**: No longer testing dual frameworks
- **Clear Support Policy**: Explicit requirement documented in README

## Migration Guide for Consumers
Users on .NET 8.0 have two options:
1. Upgrade to .NET 10.0+ and use this version
2. Stay on library version 0.7.3 or earlier for .NET 8 support
